### PR TITLE
chore(renovate): group vscode-languageserver-node updates into single PR

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,15 @@
       "matchPackageNames": ["@earendil-works/{/,}**"]
     },
     {
+      "description": "vscode-languageserver-node monorepo",
+      "groupName": "vscode-languageserver-node",
+      "matchPackageNames": [
+        "vscode-jsonrpc",
+        "vscode-languageserver-protocol",
+        "vscode-languageserver-types"
+      ]
+    },
+    {
       "description": "Pi core peer deps use '*' ranges and must not be auto-updated by Renovate",
       "enabled": false,
       "matchPackageNames": [

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
+  "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",


### PR DESCRIPTION
Adds a `packageRule` to `.github/renovate.json` that groups `vscode-jsonrpc`, `vscode-languageserver-protocol`, and `vscode-languageserver-types` — all from the same `Microsoft/vscode-languageserver-node` monorepo — into a single combined PR.

This avoids noise from separate PRs for packages that version together. Once this lands on main, Renovate will close the existing split PRs #86 and #87 and reopen one combined update on its next run.