### PR TITLE
feat(supi-ask-user)!: make discuss always available with text input

### DIFF
--- a/packages/supi-ask-user/CLAUDE.md
+++ b/packages/supi-ask-user/CLAUDE.md
@@ -36,7 +36,6 @@ Entrypoint: `src/ask-user.ts`
 ## Tool contract notes
 
 - `allowOther` is only valid on single-select choice questions.
-- `allowDiscuss` is form-level, not per-question.
 - `allowPartialSubmit` is form-level and only meaningful when partial progress is actionable.
 - Cancellation and abort call `ctx.abort()` from `ask-user.ts`.
 - A session-scoped lock prevents concurrent `ask_user` interactions.

--- a/packages/supi-ask-user/README.md
+++ b/packages/supi-ask-user/README.md
@@ -65,7 +65,6 @@ const controller = new AskUserController(questionnaire);
 | `intro` | string (optional) | Why the agent is asking |
 | `questions` | array (1–10) | Choice or text questions |
 | `allowPartialSubmit` | boolean (optional) | Let the user submit partial progress |
-| `allowDiscuss` | boolean (optional) | Let the user switch back into discussion instead of giving a final decision |
 
 ## Questions
 
@@ -128,7 +127,7 @@ The tool registers the following prompt guidance that the model sees:
 - Use ask_user only for blocking user input, not open-ended interviews or repo facts.
 - Use ask_user with 1-10 related questions; prefer one when possible.
 - Use ask_user `choice` for fixed options and ask_user `text` for freeform input; yes/no should be a `choice`.
-- Keep one ask_user form active at a time; use `allowOther` only for single-select choice and `allowDiscuss`/`allowPartialSubmit` only when actionable.
+- Keep one ask_user form active at a time; use `allowOther` only for single-select choice and `allowPartialSubmit` only when actionable.
 
 ## UI controls
 
@@ -148,7 +147,7 @@ Notes are available only for real `choice` options. They do not apply to `text` 
 Only exceptional action rows are visible:
 
 - `Other…` — when `allowOther` is enabled
-- `Discuss instead…` — when `allowDiscuss` is enabled
+- `Discuss instead…` — always available
 - `Submit partial answers` — when `allowPartialSubmit` is enabled
 - `Skip question` — for optional questions
 
@@ -192,7 +191,7 @@ Exceptional action rows (`Discuss instead…`, `Submit partial answers`) may app
       "placeholder": "optional"
     }
   ],
-  "allowDiscuss": true
+  "allowPartialSubmit": true
 }
 ```
 

--- a/packages/supi-ask-user/__tests__/unit/controller.test.ts
+++ b/packages/supi-ask-user/__tests__/unit/controller.test.ts
@@ -6,7 +6,6 @@ const questionnaire: NormalizedQuestionnaire = {
   title: "Formatter",
   intro: "Need one explicit choice.",
   allowPartialSubmit: true,
-  allowDiscuss: true,
   questions: [
     {
       type: "choice",
@@ -38,7 +37,6 @@ const multiQuestionnaire: NormalizedQuestionnaire = {
   title: "Checks",
   intro: "Pick all required checks.",
   allowPartialSubmit: false,
-  allowDiscuss: false,
   questions: [
     {
       type: "choice",

--- a/packages/supi-ask-user/__tests__/unit/normalize.test.ts
+++ b/packages/supi-ask-user/__tests__/unit/normalize.test.ts
@@ -7,7 +7,6 @@ describe("normalizeQuestionnaire", () => {
       title: " Formatter ",
       intro: " Need one explicit answer ",
       allowPartialSubmit: true,
-      allowDiscuss: true,
       questions: [
         {
           type: "choice",
@@ -36,7 +35,6 @@ describe("normalizeQuestionnaire", () => {
       title: "Formatter",
       intro: "Need one explicit answer",
       allowPartialSubmit: true,
-      allowDiscuss: true,
       questions: [
         {
           type: "choice",

--- a/packages/supi-ask-user/__tests__/unit/ui-overlay.test.ts
+++ b/packages/supi-ask-user/__tests__/unit/ui-overlay.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import type { NormalizedQuestionnaire } from "../../src/types.ts";
+import type { NormalizedQuestionnaire } from "../../src/index.ts";
 import { runOverlayQuestionnaire } from "../../src/ui/overlay.ts";
 import type { AskUserUiContext } from "../../src/ui/types.ts";
 import { makeOverlayCtx } from "../helpers/index.ts";
@@ -8,7 +8,6 @@ const questionnaire: NormalizedQuestionnaire = {
   title: "Formatter",
   intro: "Need one explicit answer.",
   allowPartialSubmit: true,
-  allowDiscuss: true,
   questions: [
     {
       type: "choice",
@@ -32,7 +31,6 @@ const twoStepQuestionnaire: NormalizedQuestionnaire = {
   title: "Two step",
   intro: "Need two answers.",
   allowPartialSubmit: false,
-  allowDiscuss: false,
   questions: [
     {
       type: "choice",
@@ -71,7 +69,6 @@ const textQuestionnaire: NormalizedQuestionnaire = {
   title: "Reason",
   intro: "Need a short explanation.",
   allowPartialSubmit: true,
-  allowDiscuss: true,
   questions: [
     {
       type: "text",
@@ -89,7 +86,6 @@ const multiQuestionnaire: NormalizedQuestionnaire = {
   title: "Checks",
   intro: "Need all required checks.",
   allowPartialSubmit: false,
-  allowDiscuss: false,
   questions: [
     {
       type: "choice",

--- a/packages/supi-ask-user/src/normalize.ts
+++ b/packages/supi-ask-user/src/normalize.ts
@@ -50,7 +50,6 @@ export function normalizeQuestionnaire(params: AskUserParams): NormalizedQuestio
     ...(intro ? { intro } : {}),
     questions,
     allowPartialSubmit: params.allowPartialSubmit ?? false,
-    allowDiscuss: params.allowDiscuss ?? false,
   };
 }
 

--- a/packages/supi-ask-user/src/schema.ts
+++ b/packages/supi-ask-user/src/schema.ts
@@ -86,11 +86,6 @@ export const AskUserParamsSchema = Type.Object({
       description: "Allow partial submission",
     }),
   ),
-  allowDiscuss: Type.Optional(
-    Type.Boolean({
-      description: "Allow discussion handoff",
-    }),
-  ),
 });
 
 export type AskUserParams = Static<typeof AskUserParamsSchema>;

--- a/packages/supi-ask-user/src/session/controller.ts
+++ b/packages/supi-ask-user/src/session/controller.ts
@@ -180,7 +180,7 @@ export class AskUserController {
   }
 
   finishDiscuss(message?: string): boolean {
-    if (!this.questionnaire.allowDiscuss || this.isTerminal) return false;
+    if (this.isTerminal) return false;
     this.status = "discuss";
     this.discussMessage = trimOptional(message);
     return true;

--- a/packages/supi-ask-user/src/tool/guidance.ts
+++ b/packages/supi-ask-user/src/tool/guidance.ts
@@ -9,5 +9,5 @@ export const promptGuidelines = [
   "Use ask_user only for blocking user input, not open-ended interviews or repo facts.",
   "Use ask_user with 1-10 related questions; prefer one when possible.",
   "Use ask_user `choice` for fixed options and ask_user `text` for freeform input; yes/no should be a `choice`.",
-  "Keep one ask_user form active at a time; use `allowOther` only for single-select choice and `allowDiscuss`/`allowPartialSubmit` only when actionable.",
+  "Keep one ask_user form active at a time; use `allowOther` only for single-select choice and `allowPartialSubmit` only when actionable.",
 ];

--- a/packages/supi-ask-user/src/types.ts
+++ b/packages/supi-ask-user/src/types.ts
@@ -40,7 +40,6 @@ export interface NormalizedQuestionnaire {
   intro?: string;
   questions: NormalizedQuestion[];
   allowPartialSubmit: boolean;
-  allowDiscuss: boolean;
 }
 
 /**

--- a/packages/supi-ask-user/src/ui/overlay-view.ts
+++ b/packages/supi-ask-user/src/ui/overlay-view.ts
@@ -302,7 +302,7 @@ function buildExceptionalActions(
 ): OverlayAction[] {
   const actions: OverlayAction[] = [];
   if (!required) actions.push("skip");
-  if (controller.questionnaire.allowDiscuss) actions.push("discuss");
+  actions.push("discuss");
   if (controller.canPartialSubmit()) actions.push("partial");
   return actions;
 }


### PR DESCRIPTION
Remove the `allowDiscuss` flag entirely — discuss is now unconditional on every form. Users can always select "Discuss instead…" to open a text editor, and the message is passed back as `discussMessage` in the outcome.

**Breaking:** `allowDiscuss` parameter removed from schema (pre-release — intentional breaking change per project policy).