### PR TITLE
feat(ask-user): reuse registered custom editor for the dialog text field

### DIFF
--- a/packages/supi-ask-user/CLAUDE.md
+++ b/packages/supi-ask-user/CLAUDE.md
@@ -51,6 +51,8 @@ import { normalizeQuestionnaire, AskUserController } from "@mrclrchtr/supi-ask-u
 - Text questions reserve printable input for the editor; use `Alt+C` for question comments and `Alt+U` for unanswered. On choice questions, plain `c` and `u` work.
 - Option comments are **preserved on deselection** — only removed when explicitly cleared. Only touched options (selected and/or commented) appear in responses.
 - In comment editors, `Esc` discards unsaved edits and returns to form/review **without cancelling the interaction**.
+- A registered custom editor is instantiated once per form and reused for text answers and every comment surface. Invalid or throwing factories warn and fall back to the default editor.
+- Embedded `CustomEditor` instances receive `Esc` first for modal transitions; delegated interrupts return to Ask User's cancel/discard behavior. Main-prompt action handlers are not reproduced inside the form.
 - `recommendation` on single-select defaults to first option; on multi-select defaults to none.
 - Completed forms are labeled `decision` in the session tree for visibility and filtering (`labeled-only` filter mode in `/tree`). Results are persisted as a custom session entry (`pi.appendEntry("ask_user", ...)`) for state tracking. In chat history, results can be expanded read-only with `Ctrl+O` — this does not reopen the live form.
 - Model-visible result summaries are truncated to Pi's default 2,000-line / 50KB tool-output limits with a clear truncation notice.

--- a/packages/supi-ask-user/README.md
+++ b/packages/supi-ask-user/README.md
@@ -30,7 +30,7 @@ All questions are expected to be answered before the form can be submitted. If y
 
 You can also add comments to individual questions, options, or the whole form if you want to explain your thinking.
 
-If you have configured a custom Pi editor, such as a Vim or Emacs editor, Ask User reuses it for text answers and all comment fields. The decision form keeps ownership of its navigation shortcuts; main-prompt actions such as model switching are not reproduced inside the form.
+If you have configured a custom Pi editor, such as a Vim or Emacs editor, Ask User creates one editor instance per form and reuses it for text answers and all comment fields. If the custom editor cannot be initialized or does not satisfy Pi's editor contract, Ask User warns and uses the default editor for that form. The decision form keeps ownership of its navigation shortcuts; main-prompt actions such as model switching are not reproduced inside the form.
 
 ## Agent-facing behavior
 

--- a/packages/supi-ask-user/README.md
+++ b/packages/supi-ask-user/README.md
@@ -30,6 +30,8 @@ All questions are expected to be answered before the form can be submitted. If y
 
 You can also add comments to individual questions, options, or the whole form if you want to explain your thinking.
 
+If you have configured a custom Pi editor, such as a Vim or Emacs editor, Ask User reuses it for text answers and all comment fields. The decision form keeps ownership of its navigation shortcuts; main-prompt actions such as model switching are not reproduced inside the form.
+
 ## Agent-facing behavior
 
 `ask_user` is an interactive TUI-only handoff. The agent should use one form for one focused decision, combine related questions instead of opening multiple forms, and wait for the result before doing work that depends on your answer. Only one form can be active at a time.
@@ -109,5 +111,7 @@ The model-visible result summary is bounded to Pi's default tool-output limits: 
 |-----|--------|
 | `Enter` | Save comment and return |
 | `Esc` | Discard comment edits and return |
+
+With a modal custom editor, `Esc` is offered to the editor first so it can leave insert mode. When the editor delegates the interrupt, Ask User performs the cancel or discard action shown above.
 
 The recommended option is labeled `[recommended]`. On wide terminals, option details render side-by-side with the list; on narrow terminals they stack below.

--- a/packages/supi-ask-user/__tests__/unit/ask-user.test.ts
+++ b/packages/supi-ask-user/__tests__/unit/ask-user.test.ts
@@ -29,6 +29,7 @@ type FormCtx = Omit<ReturnType<typeof makeCtx>, "ui"> & {
       ) => unknown,
     ) => Promise<unknown>;
     setWorkingVisible: ReturnType<typeof vi.fn>;
+    getEditorComponent?: ReturnType<typeof vi.fn>;
   };
 };
 
@@ -161,6 +162,30 @@ describe("ask_user tool", () => {
     expect(result.content[0]?.text).toContain("Prettier");
     expect(result.content[0]?.text).toContain("Avoid here");
     expect(ctx.abort).not.toHaveBeenCalled();
+  });
+
+  it("forwards the configured editor lookup to the form renderer", async () => {
+    const pi = createPiMock() as unknown as PiApi;
+    askUserExtension(pi);
+    const tool = getTool(pi, "ask_user");
+    const ctx = makeFormCtx({
+      outcome: "submitted",
+      responses: [
+        {
+          questionId: "formatter",
+          answer: {
+            kind: "choice",
+            answered: true,
+            options: [{ value: "biome", label: "Biome", selected: true }],
+          },
+        },
+      ],
+    });
+    ctx.ui.getEditorComponent = vi.fn(() => undefined);
+
+    await tool.execute("tc-editor", request, undefined, undefined, ctx);
+
+    expect(ctx.ui.getEditorComponent).toHaveBeenCalledTimes(1);
   });
 
   it("aborts the turn when the form returns an internal cancel result", async () => {

--- a/packages/supi-ask-user/__tests__/unit/ui-form.test.ts
+++ b/packages/supi-ask-user/__tests__/unit/ui-form.test.ts
@@ -2,8 +2,39 @@ import { visibleWidth } from "@earendil-works/pi-tui";
 import { describe, expect, it } from "vitest";
 import type { NormalizedQuestionnaire } from "../../src/types.ts";
 import { runFormQuestionnaire } from "../../src/ui/form.ts";
-import type { AskUserUiContext } from "../../src/ui/types.ts";
+import type { AskUserUiContext, EditorFactory } from "../../src/ui/types.ts";
 import { makeFormCtx } from "../helpers/index.ts";
+
+class FakeEditor {
+  text = "";
+  onChange?: (text: string) => void;
+  onSubmit?: (text: string) => void;
+  handledInputs: string[] = [];
+
+  render(_width: number): string[] {
+    return [`FAKE_EDITOR:${this.text}`];
+  }
+
+  invalidate(): void {}
+
+  getText(): string {
+    return this.text;
+  }
+
+  setText(value: string): void {
+    this.text = value;
+  }
+
+  handleInput(data: string): void {
+    this.handledInputs.push(data);
+    if (data === "\r") {
+      this.onSubmit?.(this.text);
+      return;
+    }
+    this.text += data;
+    this.onChange?.(this.text);
+  }
+}
 
 const questionnaire: NormalizedQuestionnaire = {
   title: "Formatter",
@@ -1072,6 +1103,82 @@ describe("runFormQuestionnaire", () => {
       });
 
       expect(outcome).toMatchObject({ kind: "abort" });
+    });
+  });
+
+  describe("registered custom editor", () => {
+    it("routes text-question keystrokes to a registered custom editor", async () => {
+      const fakeEditor = new FakeEditor();
+      let factoryCalls = 0;
+      const editorFactory: EditorFactory = (tui, theme, keybindings) => {
+        factoryCalls += 1;
+        expect(tui).toBeDefined();
+        expect(theme).toBeDefined();
+        expect(keybindings).toBeDefined();
+        return fakeEditor as unknown as ReturnType<EditorFactory>;
+      };
+
+      const { captured, ctx, outcomePromise } = makeFormCtx();
+      const uiWithEditor = {
+        ...ctx.ui,
+        getEditorComponent: () => editorFactory,
+      } as unknown as AskUserUiContext;
+
+      void runFormQuestionnaire(
+        {
+          questions: [
+            {
+              type: "text",
+              id: "reason",
+              header: "Reason",
+              prompt: "Type the reason.",
+            },
+          ],
+        },
+        {
+          ui: uiWithEditor,
+        },
+      );
+
+      await Promise.resolve();
+      if (!captured.value) throw new Error("form component was not created");
+      expect(factoryCalls).toBe(1);
+
+      const rendered = captured.value.render(100).join("\n");
+      expect(rendered).toContain("FAKE_EDITOR:");
+
+      for (const char of "vim answer") captured.value.handleInput?.(char);
+      expect(fakeEditor.handledInputs).toContain("v");
+      captured.value.handleInput?.(enterKey());
+      captured.value.handleInput?.(enterKey());
+
+      const outcome2 = await outcomePromise;
+      if (!("outcome" in outcome2)) throw new Error("Expected submitted outcome");
+      expect(outcome2.responses[0]?.answer).toMatchObject({
+        kind: "text",
+        answered: true,
+        value: "vim answer",
+      });
+    });
+
+    it("falls back to the default editor when no custom editor is registered", async () => {
+      const { captured, ctx, outcomePromise } = makeFormCtx();
+
+      void runFormQuestionnaire(textQuestionnaire, {
+        ui: ctx.ui as unknown as AskUserUiContext,
+      });
+
+      await Promise.resolve();
+      if (!captured.value) throw new Error("form component was not created");
+
+      const rendered = captured.value.render(100).join("\n");
+      expect(rendered).not.toContain("FAKE_EDITOR:");
+
+      captured.value.handleInput?.(enterKey());
+      captured.value.handleInput?.(enterKey());
+      const outcome = await outcomePromise;
+      if (!("outcome" in outcome)) throw new Error("Expected outcome");
+      expect(outcome.responses[0]?.answer).toMatchObject({ kind: "text", answered: true });
     });
   });
 });

--- a/packages/supi-ask-user/__tests__/unit/ui-form.test.ts
+++ b/packages/supi-ask-user/__tests__/unit/ui-form.test.ts
@@ -1,11 +1,11 @@
-import { visibleWidth } from "@earendil-works/pi-tui";
+import { type EditorComponent, visibleWidth } from "@earendil-works/pi-tui";
 import { describe, expect, it } from "vitest";
 import type { NormalizedQuestionnaire } from "../../src/types.ts";
 import { runFormQuestionnaire } from "../../src/ui/form.ts";
 import type { AskUserUiContext, EditorFactory } from "../../src/ui/types.ts";
 import { makeFormCtx } from "../helpers/index.ts";
 
-class FakeEditor {
+class FakeEditor implements EditorComponent {
   text = "";
   onChange?: (text: string) => void;
   onSubmit?: (text: string) => void;
@@ -33,6 +33,23 @@ class FakeEditor {
     }
     this.text += data;
     this.onChange?.(this.text);
+  }
+}
+
+class FakeModalEditor extends FakeEditor {
+  mode: "insert" | "normal" = "insert";
+  onEscape?: () => void;
+
+  override handleInput(data: string): void {
+    if (data === "\u001b") {
+      if (this.mode === "insert") {
+        this.mode = "normal";
+      } else {
+        this.onEscape?.();
+      }
+      return;
+    }
+    super.handleInput(data);
   }
 }
 
@@ -1115,7 +1132,7 @@ describe("runFormQuestionnaire", () => {
         expect(tui).toBeDefined();
         expect(theme).toBeDefined();
         expect(keybindings).toBeDefined();
-        return fakeEditor as unknown as ReturnType<EditorFactory>;
+        return fakeEditor;
       };
 
       const { captured, ctx, outcomePromise } = makeFormCtx();
@@ -1159,6 +1176,94 @@ describe("runFormQuestionnaire", () => {
         answered: true,
         value: "vim answer",
       });
+    });
+
+    it("lets a modal editor leave insert mode before cancelling the form", async () => {
+      const modalEditor = new FakeModalEditor();
+      const editorFactory: EditorFactory = () => modalEditor;
+      const { captured, ctx, outcomePromise } = makeFormCtx();
+      const uiWithEditor = {
+        ...ctx.ui,
+        getEditorComponent: () => editorFactory,
+      } as unknown as AskUserUiContext;
+
+      void runFormQuestionnaire(textQuestionnaire, { ui: uiWithEditor });
+
+      await Promise.resolve();
+      if (!captured.value) throw new Error("form component was not created");
+
+      captured.value.handleInput?.(escKey());
+      expect(modalEditor.mode).toBe("normal");
+
+      captured.value.handleInput?.(escKey());
+      await expect(outcomePromise).resolves.toMatchObject({ kind: "cancel" });
+    });
+
+    it("reuses the modal editor for every comment surface", async () => {
+      const modalEditor = new FakeModalEditor();
+      let factoryCalls = 0;
+      const editorFactory: EditorFactory = () => {
+        factoryCalls += 1;
+        return modalEditor;
+      };
+      const { captured, ctx } = makeFormCtx();
+      const uiWithEditor = {
+        ...ctx.ui,
+        getEditorComponent: () => editorFactory,
+      } as unknown as AskUserUiContext;
+
+      void runFormQuestionnaire(questionnaire, { ui: uiWithEditor });
+
+      await Promise.resolve();
+      if (!captured.value) throw new Error("form component was not created");
+
+      captured.value.handleInput?.("c");
+      expect(captured.value.render(100).join("\n")).toContain("FAKE_EDITOR:");
+      captured.value.handleInput?.(escKey());
+      captured.value.handleInput?.(escKey());
+
+      captured.value.handleInput?.("n");
+      expect(captured.value.render(100).join("\n")).toContain("FAKE_EDITOR:");
+      captured.value.handleInput?.(escKey());
+
+      captured.value.handleInput?.(enterKey());
+      captured.value.handleInput?.("c");
+      expect(captured.value.render(100).join("\n")).toContain("FAKE_EDITOR:");
+      expect(modalEditor.mode).toBe("normal");
+      expect(factoryCalls).toBe(1);
+    });
+
+    it.each([
+      [
+        "throws",
+        (() => {
+          throw new Error("broken editor");
+        }) satisfies EditorFactory,
+      ],
+      ["returns an invalid component", (() => ({})) as unknown as EditorFactory],
+    ])("warns and uses the default editor when the custom factory %s", async (_case, factory) => {
+      const { captured, ctx, outcomePromise } = makeFormCtx();
+      const uiWithEditor = {
+        ...ctx.ui,
+        getEditorComponent: () => factory,
+      } as unknown as AskUserUiContext;
+      let rejection: unknown;
+
+      void runFormQuestionnaire(textQuestionnaire, { ui: uiWithEditor }).catch((error: unknown) => {
+        rejection = error;
+      });
+
+      await Promise.resolve();
+      expect(rejection).toBeUndefined();
+      if (!captured.value) throw new Error("form component was not created");
+      expect(ctx.ui.notify).toHaveBeenCalledWith(
+        expect.stringContaining("using the default editor"),
+        "warning",
+      );
+
+      captured.value.handleInput?.(enterKey());
+      captured.value.handleInput?.(enterKey());
+      await expect(outcomePromise).resolves.toMatchObject({ outcome: "submitted" });
     });
 
     it("falls back to the default editor when no custom editor is registered", async () => {

--- a/packages/supi-ask-user/src/ask-user.ts
+++ b/packages/supi-ask-user/src/ask-user.ts
@@ -22,6 +22,7 @@ import type {
   NormalizedQuestionnaire,
 } from "./types.ts";
 import { runQuestionnaire } from "./ui/choose-renderer.ts";
+import type { EditorFactory } from "./ui/types.ts";
 
 export type AskUserExecutionContext = Pick<ExtensionContext, "cwd" | "hasUI" | "mode" | "abort"> & {
   ui: {
@@ -31,6 +32,7 @@ export type AskUserExecutionContext = Pick<ExtensionContext, "cwd" | "hasUI" | "
     setTitle?(title: string): void;
     getToolsExpanded?(): boolean;
     setToolsExpanded?(expanded: boolean): void;
+    getEditorComponent?(): EditorFactory | undefined;
   };
 };
 
@@ -141,6 +143,9 @@ export async function executeAskUser(
       ui: {
         custom: asFunction(ctx.ui.custom),
         notify: ctx.ui.notify,
+        getEditorComponent: ctx.ui.getEditorComponent
+          ? () => ctx.ui.getEditorComponent?.()
+          : undefined,
       },
       signal,
       onToggleToolsExpanded:

--- a/packages/supi-ask-user/src/ui/form-component.ts
+++ b/packages/supi-ask-user/src/ui/form-component.ts
@@ -19,6 +19,7 @@ export class AskUserForm implements Component, Focusable {
   private mode: FormMode = "choice";
   private focus: FocusTarget = "choices";
   private readonly editor: EditorComponent;
+  private readonly editorHandlesEscape: boolean;
   private settingEditorText: boolean = false;
   private choiceFocusIndex = 0;
   private readonly choiceFocusByQuestionId = new Map<string, number>();
@@ -36,16 +37,17 @@ export class AskUserForm implements Component, Focusable {
   private readonly onAbort: () => void;
 
   constructor(private readonly args: FormArgs) {
-    const editorTheme = makeEditorTheme(args);
-    this.editor = args.editorFactory
-      ? args.editorFactory(args.tui, editorTheme, args.keybindings)
-      : new Editor(args.tui, editorTheme);
-    this.editor.onChange = () => {
-      if (this.settingEditorText) return;
-      this.syncTextAnswerFromEditor();
-      this.refresh();
-    };
-    this.editor.onSubmit = (value) => this.handleEditorSubmit(value);
+    const { editor, handlesEscape } = createFormEditor(args, {
+      onChange: () => {
+        if (this.settingEditorText) return;
+        this.syncTextAnswerFromEditor();
+        this.refresh();
+      },
+      onSubmit: (value) => this.handleEditorSubmit(value),
+      onEscape: () => this.handleEditorEscape(),
+    });
+    this.editor = editor;
+    this.editorHandlesEscape = handlesEscape;
     this.syncCurrentQuestion();
     this.onAbort = () => {
       this.args.controller.abort();
@@ -117,6 +119,12 @@ export class AskUserForm implements Component, Focusable {
   private handleEscapeKey(data: string): boolean {
     if (!matchesKey(data, Key.escape)) return false;
 
+    if (this.editorHandlesEscape && (this.mode === "text" || this.isCommentEditorMode())) {
+      this.editor.handleInput(data);
+      if (!this.closed) this.refresh();
+      return true;
+    }
+
     if (this.isCommentEditorMode()) {
       this.returnFromCommentEditor();
       this.refresh();
@@ -138,6 +146,18 @@ export class AskUserForm implements Component, Focusable {
     this.args.controller.cancel();
     this.finish();
     return true;
+  }
+
+  private handleEditorEscape(): void {
+    if (this.isCommentEditorMode()) {
+      this.returnFromCommentEditor();
+      this.refresh();
+      return;
+    }
+    if (this.mode === "text") {
+      this.args.controller.cancel();
+      this.finish();
+    }
   }
 
   private handleNavigationKey(data: string): boolean {
@@ -566,6 +586,62 @@ export class AskUserForm implements Component, Focusable {
         return undefined;
     }
   }
+}
+
+interface FormEditorCallbacks {
+  onChange: (value: string) => void;
+  onSubmit: (value: string) => void;
+  onEscape: () => void;
+}
+
+function createFormEditor(
+  args: FormArgs,
+  callbacks: FormEditorCallbacks,
+): { editor: EditorComponent; handlesEscape: boolean } {
+  const editorTheme = makeEditorTheme(args);
+  const createDefault = () => {
+    const editor = new Editor(args.tui, editorTheme);
+    configureFormEditor(editor, callbacks, false);
+    return { editor, handlesEscape: false };
+  };
+  if (!args.editorFactory) return createDefault();
+
+  try {
+    const editor: unknown = args.editorFactory(args.tui, editorTheme, args.keybindings);
+    if (!isEditorComponent(editor)) {
+      throw new Error("factory returned an invalid EditorComponent");
+    }
+    const handlesEscape = "onEscape" in editor;
+    configureFormEditor(editor, callbacks, handlesEscape);
+    return { editor, handlesEscape };
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    args.notify?.(
+      `Custom editor unavailable in ask_user; using the default editor: ${reason}`,
+      "warning",
+    );
+    return createDefault();
+  }
+}
+
+function configureFormEditor(
+  editor: EditorComponent,
+  callbacks: FormEditorCallbacks,
+  handlesEscape: boolean,
+): void {
+  editor.onChange = callbacks.onChange;
+  editor.onSubmit = callbacks.onSubmit;
+  if (handlesEscape) {
+    (editor as EditorComponent & { onEscape: () => void }).onEscape = callbacks.onEscape;
+  }
+}
+
+function isEditorComponent(value: unknown): value is EditorComponent {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as Record<string, unknown>;
+  return ["render", "invalidate", "getText", "setText", "handleInput"].every(
+    (method) => typeof candidate[method] === "function",
+  );
 }
 
 function makeEditorTheme(args: FormArgs): EditorTheme {

--- a/packages/supi-ask-user/src/ui/form-component.ts
+++ b/packages/supi-ask-user/src/ui/form-component.ts
@@ -2,8 +2,10 @@
 import {
   type Component,
   Editor,
+  type EditorComponent,
   type EditorTheme,
   type Focusable,
+  isFocusable,
   Key,
   matchesKey,
 } from "@earendil-works/pi-tui";
@@ -16,7 +18,7 @@ export class AskUserForm implements Component, Focusable {
   focused: boolean = false;
   private mode: FormMode = "choice";
   private focus: FocusTarget = "choices";
-  private readonly editor: Editor;
+  private readonly editor: EditorComponent;
   private settingEditorText: boolean = false;
   private choiceFocusIndex = 0;
   private readonly choiceFocusByQuestionId = new Map<string, number>();
@@ -34,7 +36,10 @@ export class AskUserForm implements Component, Focusable {
   private readonly onAbort: () => void;
 
   constructor(private readonly args: FormArgs) {
-    this.editor = new Editor(args.tui, makeEditorTheme(args));
+    const editorTheme = makeEditorTheme(args);
+    this.editor = args.editorFactory
+      ? args.editorFactory(args.tui, editorTheme, args.keybindings)
+      : new Editor(args.tui, editorTheme);
     this.editor.onChange = () => {
       if (this.settingEditorText) return;
       this.syncTextAnswerFromEditor();
@@ -51,7 +56,7 @@ export class AskUserForm implements Component, Focusable {
 
   render(width: number): string[] {
     const editorFocused = this.focused && this.focus === "editor";
-    this.editor.focused = editorFocused;
+    if (isFocusable(this.editor)) this.editor.focused = editorFocused;
 
     if (
       this.cachedWidth === width &&
@@ -497,7 +502,10 @@ export class AskUserForm implements Component, Focusable {
     if (this.mode !== "text") return;
     const question = this.args.controller.currentQuestion;
     if (question.type !== "text") return;
-    this.args.controller.setTextAnswer(question.id, this.editor.getExpandedText());
+    this.args.controller.setTextAnswer(
+      question.id,
+      this.editor.getExpandedText?.() ?? this.editor.getText(),
+    );
   }
 
   private restoreChoiceFocus(

--- a/packages/supi-ask-user/src/ui/form-render.ts
+++ b/packages/supi-ask-user/src/ui/form-render.ts
@@ -1,5 +1,5 @@
 import type { Theme } from "@earendil-works/pi-coding-agent";
-import { type Editor, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
+import { type EditorComponent, truncateToWidth, wrapTextWithAnsi } from "@earendil-works/pi-tui";
 import type { AskUserController } from "../session/controller.ts";
 import type { NormalizedChoiceQuestion } from "../types.ts";
 import {
@@ -19,7 +19,7 @@ export interface RenderFormFrameArgs {
   controller: AskUserController;
   mode: FormMode;
   focus: FocusTarget;
-  editor: Editor;
+  editor: EditorComponent;
   choiceFocusIndex: number;
   reviewFocusIndex: number;
   detailsText?: string;

--- a/packages/supi-ask-user/src/ui/form.ts
+++ b/packages/supi-ask-user/src/ui/form.ts
@@ -29,6 +29,7 @@ export async function runFormQuestionnaire(
         keybindings: kb,
         onToggleToolsExpanded: opts.onToggleToolsExpanded,
         editorFactory,
+        notify: opts.ui.notify,
       }),
   );
 }

--- a/packages/supi-ask-user/src/ui/form.ts
+++ b/packages/supi-ask-user/src/ui/form.ts
@@ -16,6 +16,8 @@ export async function runFormQuestionnaire(
     return controller.abort();
   }
 
+  const editorFactory = opts.ui.getEditorComponent?.();
+
   return opts.ui.custom?.<AskUserOutcome | AskUserInteractionResult>(
     (tui, theme, kb, done) =>
       new AskUserForm({
@@ -26,6 +28,7 @@ export async function runFormQuestionnaire(
         signal: opts.signal,
         keybindings: kb,
         onToggleToolsExpanded: opts.onToggleToolsExpanded,
+        editorFactory,
       }),
   );
 }

--- a/packages/supi-ask-user/src/ui/types.ts
+++ b/packages/supi-ask-user/src/ui/types.ts
@@ -1,4 +1,8 @@
-import type { KeybindingsManager, Theme } from "@earendil-works/pi-coding-agent";
+import type {
+  ExtensionUIContext,
+  KeybindingsManager,
+  Theme,
+} from "@earendil-works/pi-coding-agent";
 import type { Component, TUI } from "@earendil-works/pi-tui";
 import type { AskUserController } from "../session/controller.ts";
 import type {
@@ -7,8 +11,13 @@ import type {
   NormalizedQuestionnaire,
 } from "../types.ts";
 
+// `EditorFactory` isn't re-exported from the package root; derive it from the
+// interface method that is exported.
+export type EditorFactory = NonNullable<ReturnType<ExtensionUIContext["getEditorComponent"]>>;
+
 export interface AskUserUiContext {
   notify?(message: string, type?: "info" | "warning" | "error"): void;
+  getEditorComponent?(): EditorFactory | undefined;
   custom?<T>(
     factory: (
       tui: TUI,
@@ -39,4 +48,5 @@ export interface FormArgs {
   signal?: AbortSignal;
   keybindings: KeybindingsManager;
   onToggleToolsExpanded?: () => void;
+  editorFactory?: EditorFactory;
 }

--- a/packages/supi-ask-user/src/ui/types.ts
+++ b/packages/supi-ask-user/src/ui/types.ts
@@ -49,4 +49,5 @@ export interface FormArgs {
   keybindings: KeybindingsManager;
   onToggleToolsExpanded?: () => void;
   editorFactory?: EditorFactory;
+  notify?: AskUserUiContext["notify"];
 }


### PR DESCRIPTION
Fixes #195.

## Problem

The ask-user dialog built its text/comment field with the default pi-tui `Editor`, so it ignored editors registered through `ctx.ui.setEditorComponent(...)`. Vim and Emacs users therefore lost their configured editing model inside decision forms.

A factory-only swap was not sufficient for modal editors because Ask User intercepted `Esc` before the editor could leave insert mode.

## Change

- Forward `ctx.ui.getEditorComponent()` into the form while preserving its receiver.
- Create one registered editor instance per form and reuse it for text answers plus question, option, and form comments.
- Fall back to the default `Editor` when no custom editor is registered.
- Treat the field as `EditorComponent`, guard focus with `isFocusable()`, and fall back from `getExpandedText()` to `getText()`.
- Let `CustomEditor`-compatible instances receive `Esc` first, then bridge delegated interrupts back to Ask User's cancel/discard behavior.
- Validate factory results; warn and use the default editor when initialization fails or the returned component is invalid.
- Document that the decision form retains its own navigation and does not reproduce main-prompt actions.

`EditorFactory` is derived from the exported `ExtensionUIContext["getEditorComponent"]` return type because it is not re-exported from the package root.

## Follow-up

Non-conflicting main-prompt actions such as model switching are tracked in #198. Pi currently exposes the editor factory but not the private app-action wiring used by the main prompt.

## Verification

- `pnpm verify:ai`
- 221 test files passed, 2 skipped
- 2,325 tests passed, 4 skipped
- All 18 packages packed and verified
