### PR TITLE
fix(supi-code-intelligence): harmonize coordinate error message with tool specs (fixes #231)

### DIFF
--- a/packages/supi-code-intelligence/__tests__/unit/tool/resolve/code-resolve-tool.test.ts
+++ b/packages/supi-code-intelligence/__tests__/unit/tool/resolve/code-resolve-tool.test.ts
@@ -1233,6 +1233,25 @@ describe("code_resolve anchored symbol resolution", () => {
     expect(whitespaceRes.details?.data.targets).toEqual([]);
   });
 
+  it("returns Coordinate resolution returned no target message when no symbol resolved", async () => {
+    const file = writeWidget(tmpDir);
+    registerMockProvider(tmpDir, { documentSymbols: async () => [] });
+
+    const pi = createPiMock();
+    codeIntelligenceExtension(pi as never, sessionCache.getOrCreate);
+    const tool = getTool(pi, "code_resolve");
+
+    const res = (await tool.execute(
+      "unresolved-coord",
+      { file: "src/widget.ts", line: 3, character: 1 },
+      undefined,
+      undefined,
+      makeCtx({ cwd: tmpDir }),
+    )) as { content: Array<{ type: string; text: string }> };
+
+    expect(res.content[0].text).toContain("Coordinate resolution returned no target");
+  });
+
   it("follows up with code_graph callees using a snapped name-anchor targetId", async () => {
     const file = writeWidget(tmpDir);
     registerMockProvider(tmpDir, {

--- a/packages/supi-code-intelligence/src/analysis/target/anchored.ts
+++ b/packages/supi-code-intelligence/src/analysis/target/anchored.ts
@@ -342,7 +342,7 @@ function coordinateNotOnSymbolMessage(
   const at = `${path.basename(file)}:${line}:${character}`;
   const reason = detail ? ` (on \`${detail}\`)` : "";
   return (
-    `**Error:** No symbol target resolved at \`${at}\`${reason}. ` +
+    `**Error:** Coordinate resolution returned no target at \`${at}\`${reason}. ` +
     "`code_resolve` resolves real symbol targets from provider-backed evidence; " +
     "use `code_inspect` for point-level facts at this coordinate, or pass the identifier coordinate of a declaration."
   );


### PR DESCRIPTION
## Summary
Fixes #231.

## Changes
- Updated `coordinateNotOnSymbolMessage` in `packages/supi-code-intelligence/src/analysis/target/anchored.ts` to use `Coordinate resolution returned no target` prefix, matching the format emitted by `precise-target.ts`.
- Added unit test in `code-resolve-tool.test.ts` to verify the formatted error text when no symbol resolves at the target coordinate.