### PR TITLE
feat(supi-prompt-suggestions): accept suggestion with Tab

### DIFF
--- a/packages/supi-prompt-suggestions/README.md
+++ b/packages/supi-prompt-suggestions/README.md
@@ -34,7 +34,7 @@ Suggestions only appear when:
 
 | Key | Action |
 |-----|--------|
-| `→` / Right Arrow | Accept the suggestion into the editor without submitting it |
+| `→` / Right Arrow / `Tab` | Accept the suggestion into the editor without submitting it |
 | `Esc` | Dismiss the visible suggestion |
 | Any text input | Hide the suggestion and continue typing |
 | Delete all editor text | Restore the hidden suggestion |

--- a/packages/supi-prompt-suggestions/__tests__/unit/editor.test.ts
+++ b/packages/supi-prompt-suggestions/__tests__/unit/editor.test.ts
@@ -146,6 +146,16 @@ describe("GhostTextEditor input handling", () => {
     expect(cbs.onAccept).toHaveBeenCalledWith("suggest");
   });
 
+  it("accepts suggestion on Tab", () => {
+    const cbs = makeCallbacks();
+    const editor = makeEditor(cbs);
+    editor.setSuggestion("suggest");
+
+    editor.handleInput("\t");
+    expect(cbs.onAccept).toHaveBeenCalledWith("suggest");
+    expect(cbs.onDismiss).not.toHaveBeenCalled();
+  });
+
   it("inserts the full suggestion after a wrapped preview", () => {
     const cbs = makeCallbacks();
     const editor = makeEditor(cbs);

--- a/packages/supi-prompt-suggestions/src/editor/editor.ts
+++ b/packages/supi-prompt-suggestions/src/editor/editor.ts
@@ -67,7 +67,7 @@ export class GhostTextEditor extends CustomEditor {
     if (this.suggestion && !this.isSuppressed) {
       // Use PI's matchesKey (not raw escape sequences) — it handles
       // CSI (\x1b[C), SS3 (\x1bOC), and Kitty keyboard protocol correctly.
-      if (matchesKey(data, "right")) {
+      if (matchesKey(data, "right") || matchesKey(data, "tab")) {
         this.insertTextAtCursor(this.suggestion);
         this.callbacks.onAccept(this.suggestion);
         this.clearGhost();


### PR DESCRIPTION
## What

Adds `Tab` as a second key to accept the visible ghost-text suggestion, alongside the existing Right Arrow.

## Why

Closes #295 — currently only Right Arrow accepts a suggestion; Tab is a more conventional accept key for inline/ghost-text completions (matches the convention in most editors and other AI completion UIs).

## Change

`packages/supi-prompt-suggestions/src/editor/editor.ts`:

```diff
- if (matchesKey(data, "right")) {
+ if (matchesKey(data, "right") || matchesKey(data, "tab")) {
```

Tab has no existing binding in `GhostTextEditor`/`CustomEditor` while a suggestion is showing — ghost text only renders when the buffer is empty, so there's no conflict with tab-triggered autocomplete elsewhere in the editor.

Also updated the README key table and added a unit test covering Tab acceptance.

## Testing

- `vitest run packages/supi-prompt-suggestions` — 7 files, 70 tests pass (including new Tab test)
- `tsc -b` on the package + test project — clean
- `biome check` on touched files — clean
- Manually verified in a live pi session: patched the installed extension copy, started a fresh session, triggered a suggestion, pressed Tab — suggestion accepted into the editor.
