### PR TITLE
fix(ask-user): register ask_user only in TUI sessions

### DIFF
--- a/packages/supi-ask-user/README.md
+++ b/packages/supi-ask-user/README.md
@@ -113,7 +113,7 @@ On wide terminals, option details appear beside the choices. On narrow terminals
 
 ## Requirements, defaults, and limits
 
-- `ask_user` requires Pi's interactive TUI and custom component support. It does not run in RPC, JSON, or print mode.
+- `ask_user` requires Pi's interactive TUI and custom component support. The tool is only registered in TUI sessions and is not offered to the model in RPC, JSON, or print mode.
 - The package needs no additional binary, service, or API key.
 - Only one form can be active. The tool uses sequential execution, so sibling tool calls do not run beside a live form.
 - Cancelling a form cancels the current agent turn. It does not record a user response.

--- a/packages/supi-ask-user/__tests__/unit/ask-user.test.ts
+++ b/packages/supi-ask-user/__tests__/unit/ask-user.test.ts
@@ -1,5 +1,5 @@
 import type { ExtensionAPI } from "@earendil-works/pi-coding-agent";
-import { createPiMock, getTool, makeCtx } from "@mrclrchtr/supi-test-utils";
+import { createPiMock, getTool, getTools, makeCtx } from "@mrclrchtr/supi-test-utils";
 import { describe, expect, it, vi } from "vitest";
 // We import the extension factory but we also export executeAskUser for direct testing
 import askUserExtension from "../../src/ask-user.ts";
@@ -65,9 +65,30 @@ function makeFormCtx(result: unknown): FormCtx {
 }
 
 describe("ask_user tool", () => {
-  it("registers the ask_user tool with blocking guidance metadata at factory time", () => {
-    const pi = createPiMock() as unknown as PiApi;
+  /** Fire session_start like a real pi session so prompting-surface config
+   *  resolution and mode-gated registration run. */
+  async function fireSessionStart(
+    pi: PiApi,
+    mode: "tui" | "rpc" | "json" | "print",
+  ): Promise<void> {
+    const ctx = makeCtx({ hasUI: true, mode }) as unknown as ReturnType<typeof makeCtx>;
+    // The mock session manager lacks getSessionId, which prompt-surface diagnostics read.
+    Object.assign(ctx.sessionManager, { getSessionId: vi.fn(() => "sid-1") });
+    for (const h of pi.getHandlers("session_start")) {
+      await (h as (...args: unknown[]) => unknown)({}, ctx);
+    }
+  }
+
+  /** Register the extension and start a TUI session, as pi does at startup. */
+  async function setupTuiExtension(options: { sessionName?: string } = {}): Promise<PiApi> {
+    const pi = createPiMock(options) as unknown as PiApi;
     askUserExtension(pi);
+    await fireSessionStart(pi, "tui");
+    return pi;
+  }
+
+  it("registers the ask_user tool with blocking guidance metadata after a TUI session starts", async () => {
+    const pi = await setupTuiExtension();
     const tool = getTool(pi, "ask_user");
 
     expect(tool.label).toBe("Ask User");
@@ -86,9 +107,24 @@ describe("ask_user tool", () => {
     expect(handler).toHaveLength(2);
   });
 
-  it("throws for invalid forms", async () => {
+  it("does not register the tool at factory time", () => {
     const pi = createPiMock() as unknown as PiApi;
     askUserExtension(pi);
+    expect(getTools(pi).some((tool) => tool.name === "ask_user")).toBe(false);
+  });
+
+  it.each(["rpc", "json", "print"] as const)(
+    "does not register the tool in %s mode",
+    async (mode) => {
+      const pi = createPiMock() as unknown as PiApi;
+      askUserExtension(pi);
+      await fireSessionStart(pi, mode);
+      expect(getTools(pi).some((tool) => tool.name === "ask_user")).toBe(false);
+    },
+  );
+
+  it("throws for invalid forms", async () => {
+    const pi = await setupTuiExtension();
     const tool = getTool(pi, "ask_user");
 
     await expect(
@@ -97,8 +133,7 @@ describe("ask_user tool", () => {
   });
 
   it("throws when custom form support is unavailable", async () => {
-    const pi = createPiMock({ sessionName: "My Session" }) as unknown as PiApi;
-    askUserExtension(pi);
+    const pi = await setupTuiExtension({ sessionName: "My Session" });
     const tool = getTool(pi, "ask_user");
     const ctx = makeUnsupportedCtx();
 
@@ -108,8 +143,7 @@ describe("ask_user tool", () => {
   });
 
   it("throws in RPC mode even though ctx.hasUI is true", async () => {
-    const pi = createPiMock({ sessionName: "My Session" }) as unknown as PiApi;
-    askUserExtension(pi);
+    const pi = await setupTuiExtension({ sessionName: "My Session" });
     const tool = getTool(pi, "ask_user");
     const ctx = makeFormCtx(undefined);
     const rpcCtx = { ...ctx, hasUI: true, mode: "rpc" };
@@ -120,8 +154,7 @@ describe("ask_user tool", () => {
   });
 
   it("records successful form submissions with outcome and responses", async () => {
-    const pi = createPiMock({ sessionName: "My Session" }) as unknown as PiApi;
-    askUserExtension(pi);
+    const pi = await setupTuiExtension({ sessionName: "My Session" });
     const tool = getTool(pi, "ask_user");
     const ctx = makeFormCtx({
       outcome: "submitted",
@@ -165,8 +198,7 @@ describe("ask_user tool", () => {
   });
 
   it("forwards the configured editor lookup to the form renderer", async () => {
-    const pi = createPiMock() as unknown as PiApi;
-    askUserExtension(pi);
+    const pi = await setupTuiExtension();
     const tool = getTool(pi, "ask_user");
     const ctx = makeFormCtx({
       outcome: "submitted",
@@ -189,8 +221,7 @@ describe("ask_user tool", () => {
   });
 
   it("aborts the turn when the form returns an internal cancel result", async () => {
-    const pi = createPiMock() as unknown as PiApi;
-    askUserExtension(pi);
+    const pi = await setupTuiExtension();
     const tool = getTool(pi, "ask_user");
     const ctx = makeFormCtx({ kind: "cancel" } as AskUserInteractionResult);
 
@@ -202,8 +233,7 @@ describe("ask_user tool", () => {
   });
 
   it("aborts the turn when the form returns an internal abort result", async () => {
-    const pi = createPiMock() as unknown as PiApi;
-    askUserExtension(pi);
+    const pi = await setupTuiExtension();
     const tool = getTool(pi, "ask_user");
     const ctx = makeFormCtx({ kind: "abort" } as AskUserInteractionResult);
 
@@ -215,8 +245,7 @@ describe("ask_user tool", () => {
   });
 
   it("rejects a second concurrent ask_user call", async () => {
-    const pi = createPiMock() as unknown as PiApi;
-    askUserExtension(pi);
+    const pi = await setupTuiExtension();
     const tool = getTool(pi, "ask_user");
 
     let resolveFirst: ((value: unknown) => void) | undefined;
@@ -252,8 +281,7 @@ describe("ask_user tool", () => {
   });
 
   it("emits start and end events around successful form interaction", async () => {
-    const pi = createPiMock() as unknown as PiApi;
-    askUserExtension(pi);
+    const pi = await setupTuiExtension();
     const tool = getTool(pi, "ask_user");
 
     await tool.execute(
@@ -285,8 +313,7 @@ describe("ask_user tool", () => {
   });
 
   it("handles needs_discussion outcome without aborting", async () => {
-    const pi = createPiMock({ sessionName: "My Session" }) as unknown as PiApi;
-    askUserExtension(pi);
+    const pi = await setupTuiExtension({ sessionName: "My Session" });
     const tool = getTool(pi, "ask_user");
     const ctx = makeFormCtx({
       outcome: "needs_discussion",

--- a/packages/supi-ask-user/src/ask-user.ts
+++ b/packages/supi-ask-user/src/ask-user.ts
@@ -36,10 +36,12 @@ export default function askUserExtension(pi: ExtensionAPI): void {
     }, 0);
   });
 
-  // Factory-time: register with package defaults.
-  registerAskUserTool(pi, lock, ASK_USER_PROMPT_SURFACE_DEFAULTS, getSessionName);
-
-  // session_start: re-register with resolved prompt surface (global + trusted project config).
+  // Register ask_user only for interactive TUI sessions: the form UI has no
+  // degraded fallback, so the tool must not be offered in RPC, JSON, or print
+  // modes. The run mode is only available on the event context, not at
+  // extension factory time, so registration happens on session_start instead
+  // of eagerly at load. Config diagnostics stay mode-independent and are
+  // still reported so misconfigured prompt surfaces surface in every mode.
   pi.on("session_start", async (_event, ctx) => {
     const { surface, diagnostics } = resolveToolPromptSurface({
       section: "ask-user",
@@ -47,9 +49,11 @@ export default function askUserExtension(pi: ExtensionAPI): void {
       defaults: ASK_USER_PROMPT_SURFACE_DEFAULTS,
       ctx,
     });
+    notifyToolPromptSurfaceDiagnostics(ctx, diagnostics);
+
+    if (ctx.mode !== "tui") return;
 
     registerAskUserTool(pi, lock, surface, getSessionName);
-    notifyToolPromptSurfaceDiagnostics(ctx, diagnostics);
   });
 }
 


### PR DESCRIPTION
## Problem

`@mrclrchtr/supi-ask-user` registers `ask_user` at extension factory time in **every** run mode. In RPC/JSON/print sessions the model is offered a tool that can never succeed — execution immediately throws `ask_user requires an interactive TUI session`. That pollutes the tool list and prompt surface in headless runs and invites failing tool calls.

## Change

Registration now happens in the `session_start` handler, gated on `ctx.mode === "tui"`:

- The run mode is only available on the event context, not at extension factory time, so eager registration is replaced by mode-gated registration at session start.
- Prompt-surface config resolution and diagnostics stay mode-independent, so misconfigured `ask-user` prompt surfaces are still reported in every mode.
- In TUI sessions behavior is unchanged: the tool registers on `session_start` (startup, new, resume, fork, reload) with the resolved prompt surface.

## Tests

- New: `does not register the tool at factory time`
- New parameterized: `does not register the tool in rpc/json/print mode`
- Existing registration test now asserts the tool appears after a TUI `session_start`
- All 156 tests in the package pass; workspace `tsc -b` and `biome check` green

## Docs

README requirement note updated to state that the tool is only registered in TUI sessions.

Note: with this change, pi's **built-in** `ask_user` becomes the active `ask_user` again in RPC sessions (where it works via the RPC UI protocol). Packages that want no `ask_user` at all in RPC should disable the built-in there too — out of scope here.